### PR TITLE
Fix key for incoming message body

### DIFF
--- a/jsbf/bot.py
+++ b/jsbf/bot.py
@@ -46,7 +46,7 @@ class Bot(object):
         responses = []
         datamessage = message.get('data', {}).get('dataMessage')
         if datamessage is not None:
-            text = datamessage.get('body')
+            text = datamessage.get('body', datamessage.get('message'))
             group = datamessage.get('groupInfo')
             if group:
                 group = group.get('groupId')

--- a/jsbf/bot.py
+++ b/jsbf/bot.py
@@ -46,7 +46,7 @@ class Bot(object):
         responses = []
         datamessage = message.get('data', {}).get('dataMessage')
         if datamessage is not None:
-            text = datamessage.get('message')
+            text = datamessage.get('body')
             group = datamessage.get('groupInfo')
             if group:
                 group = group.get('groupId')


### PR DESCRIPTION
Matching `signald`'s amended format for received message (message body moved from `message` key to `body`).
Should be backward compatible as earlier key is retrieved as fallback.